### PR TITLE
Fix carousel patch regression

### DIFF
--- a/patches/@ecl__carousel.patch
+++ b/patches/@ecl__carousel.patch
@@ -123,8 +123,8 @@ index bb0daf7ebc5287514e1c929d6a10e9da714ddda0..7e496d339c32933ec2161f336cb1b343
 -        let bannerVideo = null;
 +      this.slides.forEach(function (slide) {
          const banner = queryOne('.ecl-banner', slide);
-+        const bannerImage = null;
-+        const bannerVideo = null;
++        let bannerImage = null;
++        let bannerVideo = null;
          if (banner) {
            bannerImage = queryOne('img', banner);
            bannerVideo = queryOne('video', banner);


### PR DESCRIPTION
The change from `let` to `const` [here in `@ecl__carousel.patch`](https://github.com/ec-europa/ecl-webcomponents/blob/ecl-v5-dev/patches/%40ecl__carousel.patch#L120-L130) is not appropriate because `bannerImage` and `bannerVideo` are then reassigned below:

```
       this.executionCount = 0;
-      this.slides.forEach((slide) => {
-        let bannerImage = null;
-        let bannerVideo = null;
+      this.slides.forEach(function (slide) {
         const banner = queryOne('.ecl-banner', slide);
+        const bannerImage = null;
+        const bannerVideo = null;
         if (banner) {
           bannerImage = queryOne('img', banner);
           bannerVideo = queryOne('video', banner);
```

which leads to this error when trying to use the library:

```
./node_modules/@ecl/ecl-webcomponents/dist/esm/ecl-carousel.entry.js:286:11
Ecmascript file had an error
  284 |         if (banner) {
  285 |           bannerImage = queryOne('img', banner);
> 286 |           bannerVideo = queryOne('video', banner);
      |           ^^^^^^^^^^^
  287 |           const footerHeight = parseInt(banner.style.getPropertyValue('--banner-footer-height'), 10) || 0;
  288 |           const newHeight = tallestElementHeight - footerHeight;
  289 |           banner.style.height = newHeight + "px";

cannot reassign to a variable declared with `const`
```
