### PR TITLE
Fix exports for vite/vitepress

### DIFF
--- a/packages/ecl-webcomponents-vue/package.json
+++ b/packages/ecl-webcomponents-vue/package.json
@@ -14,11 +14,12 @@
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
     "build": "npm run tsc",
-    "tsc": "tsc -p . --outDir ./dist",
+    "tsc": "npx tsc -p . --outDir ./dist",
     "pre-publish": "npm run build"
   },
   "dependencies": {
-    "@ecl/ecl-webcomponents": "0.24.1"
+    "@ecl/ecl-webcomponents": "0.24.1",
+    "@stencil/vue-output-target": "^0.13.1"
   },
   "engines": {
     "node": ">=20.0.0",
@@ -29,6 +30,7 @@
     "url": "https://github.com/ec-europa/ecl-webcomponents"
   },
   "devDependencies": {
+    "typescript": "^6.0.3",
     "vue": "3.5.30"
   }
 }

--- a/packages/ecl-webcomponents-vue/package.json
+++ b/packages/ecl-webcomponents-vue/package.json
@@ -15,7 +15,8 @@
     "test": "echo \"Error: run tests from root\" && exit 1",
     "build": "npm run tsc",
     "tsc": "npx tsc -p . --outDir ./dist",
-    "pre-publish": "npm run build"
+    "pre-publish": "npm run build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@ecl/ecl-webcomponents": "0.24.1",

--- a/packages/ecl-webcomponents-vue/tsconfig.json
+++ b/packages/ecl-webcomponents-vue/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": false,
+    "rootDir": "./lib",
     "outDir": "./dist",
     "lib": ["dom", "es2020"],
     "module": "es2015",
-    "moduleResolution": "node",
     "target": "es2017",
     "skipLibCheck": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "declaration": false,
     "experimentalDecorators": true,
     "lib": ["dom", "dom.iterable", "es2017"],
-    "moduleResolution": "node",
     "module": "esnext",
     "target": "es2017",
     "noUnusedLocals": true,


### PR DESCRIPTION
When consuming ecl-webcomponents-vue in vitepress, the vitepress build process fails due to file resove issues. Error was:

  vitepress v2.0.0-alpha.17

✓ building client + server bundles...
build error:
Cannot find module '/vitepress-ecl-webcomponents/node_modules/@ecl/ecl-webcomponents-vue/dist/components' imported from /vitepress-ecl-webcomponents/node_modules/@ecl/ecl-webcomponents-vue/dist/index.js
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/vitepress-ecl-webcomponents/node_modules/@ecl/ecl-webcomponents-vue/dist/components' imported from /vitepress-ecl-webcomponents/node_modules/@ecl/ecl-webcomponents-vue/dist/index.js
    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:932:10)
    at defaultResolve (node:internal/modules/esm/resolve:1056:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:654:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:603:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:586:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:242:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49)

These changes improve the package.json and fixes a missing dependency, so that lookup works again.

In an attempt to facilitate building `dist` when pointing in the package.json directly to github, I also added a prepare script. Unfortunately, package.json/NPM does not support packages in git subfolders.